### PR TITLE
SOFA-7: create User domain model for primary list item

### DIFF
--- a/app/src/main/java/com/example/stackoverflowapp/domain/model/User.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/domain/model/User.kt
@@ -1,0 +1,8 @@
+package com.example.stackoverflowapp.domain.model
+
+data class User(
+    val id: Int,
+    val displayName: String,
+    val reputation: Int,
+    val profileImageUrl: String?
+)

--- a/app/src/main/java/com/example/stackoverflowapp/domain/model/UserExtensions.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/domain/model/UserExtensions.kt
@@ -1,0 +1,8 @@
+package com.example.stackoverflowapp.domain.model
+
+fun User.validate(): User {
+    require(id > 0) { " User id must be positive "}
+    require(displayName.isNotBlank()) { " User name cannot be blank "}
+    require(reputation >= 0) { " User reputation must be positive "}
+    return this
+}

--- a/app/src/test/java/com/example/stackoverflowapp/domain/model/UserTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/domain/model/UserTest.kt
@@ -1,0 +1,15 @@
+package com.example.stackoverflowapp.domain.model
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class UserTest {
+    @Test
+    fun `user holds expected values`() {
+        val user = User(1, "Jeff Atwood", 9001, null)
+        assertEquals(1, user.id)
+        assertEquals("Jeff Atwood", user.displayName)
+        assertEquals(9001, user.reputation)
+        assertNull(user.profileImageUrl)
+    }
+}

--- a/app/src/test/java/com/example/stackoverflowapp/domain/model/UserValidationTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/domain/model/UserValidationTest.kt
@@ -1,0 +1,42 @@
+package com.example.stackoverflowapp.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+class UserValidationParameterizedTest(
+    @Suppress("UNUSED_PARAMETER")
+    private val caseName: String,
+    private val user: User
+) {
+
+    companion object {
+        private val jeff = User(1, "Jeff Atwood", 9001, null)
+
+        @JvmStatic
+        @Parameters(name = "{0}")
+        fun data(): List<Array<Any>> = listOf(
+            arrayOf("blank display name", jeff.copy(displayName = "")),
+            arrayOf("negative reputation", jeff.copy(reputation = -1)),
+            arrayOf("negative id", jeff.copy(id = -1)),
+            arrayOf("zero id", jeff.copy(id = 0)),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `invalid user throws`() {
+        user.validate()
+    }
+}
+
+class UserValidationTest {
+
+    @Test
+    fun `valid user passes validation`() {
+        val user = User(1, "Joel Spolsky", 9001, null)
+        assertEquals(user, user.validate())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,14 +7,12 @@ coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-appcompat = "1.7.1"
 kotlinxCoroutinesAndroid = "1.10.2"
 kotlinxCoroutinesCore = "1.10.2"
 kotlinxCoroutinesTest = "1.10.2"
 lifecycleRuntimeCompose = "2.10.0"
 lifecycleViewmodelCompose = "2.10.0"
 lifecycleViewmodelKtx = "2.10.0"
-material = "1.13.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
## 🎯 Ticket
[[SOFA-7 – Create domain model for primary list item]](https://github.com/rootMu/StackOverflowApp/issues/7)

---

## Summary
Introduces the core `User` domain model used by the application.

This model represents the minimal set of fields required for the current UI:
- `id`
- `displayName`
- `reputation`
- `profileImageUrl`

---

## Validation
Adds a `validate()` extension function to enforce domain invariants:
- `id` must be positive
- `displayName` must not be blank
- `reputation` must not be negative

This ensures downstream layers (UI, repository, etc.) can rely on consistent data assumptions.

---

## Tests Added
- Verifies domain values are correctly assigned
- Parameterized tests for invalid user cases
- Ensures validation throws appropriate exceptions
- Confirms valid user passes validation