### PR TITLE
SOFA-13: Create repository interface and implementation

### DIFF
--- a/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepository.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.example.stackoverflowapp.data.repo
+
+import com.example.stackoverflowapp.domain.model.User
+
+interface UserRepository {
+    suspend fun fetchTopUsers(): Result<List<User>>
+}

--- a/app/src/main/java/com/example/stackoverflowapp/data/repo/fake/FakeUserRepository.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/repo/fake/FakeUserRepository.kt
@@ -1,0 +1,17 @@
+package com.example.stackoverflowapp.data.repo.fake
+
+import com.example.stackoverflowapp.data.repo.UserRepository
+import com.example.stackoverflowapp.domain.model.User
+import kotlinx.coroutines.delay
+
+class FakeUserRepository: UserRepository {
+    override suspend fun fetchTopUsers(): Result<List<User>> =
+        with(delay(400)) {
+            Result.success(
+                listOf(
+                    User(1, "Jeff Atwood", 9001, null),
+                    User(1, "Joel Spolsky", 8000, null)
+                )
+            )
+        }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/di/AppContainer.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/di/AppContainer.kt
@@ -1,6 +1,8 @@
 package com.example.stackoverflowapp.di
 
 import android.content.Context
+import com.example.stackoverflowapp.data.repo.UserRepository
+import com.example.stackoverflowapp.data.repo.fake.FakeUserRepository
 
 /**
  * Central application-level dependency container.
@@ -17,4 +19,8 @@ import android.content.Context
  *
  */
 
-class AppContainer(context: Context)
+class AppContainer(context: Context) {
+
+    val userRepository: UserRepository = FakeUserRepository()
+
+}


### PR DESCRIPTION
## 🎯 Ticket
[[SOFA-13 – Create repository interface and implementation]](https://github.com/rootMu/StackOverflowApp/issues/13)

---

## Summary
Introduces a repository layer to provide a clean data access boundary between the UI/ViewModel and data source implementations.

This PR adds:
- A repository interface for fetching StackOverflow users
- A repository implementation (currently backed by the fake data source/repo setup)
- Domain model return types from the repository layer
- Repository wiring in `AppContainer` so consumers depend on the abstraction

This sets up the app for swapping in a real network-backed implementation later without changing UI/ViewModel code.
