### PR TITLE
SOFA-15: Create ViewModel with repository dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material.icons.extended)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
@@ -81,6 +82,7 @@ dependencies {
     // ----------------------------
     // Unit tests
     // ----------------------------
+    implementation(libs.androidx.ui.test.junit4)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
 

--- a/app/src/androidTest/java/com/example/stackoverflowapp/ui/components/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/example/stackoverflowapp/ui/components/HomeScreenTest.kt
@@ -1,0 +1,92 @@
+package com.example.stackoverflowapp.ui.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.example.stackoverflowapp.domain.model.User
+import com.example.stackoverflowapp.ui.home.HomeUiState
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class HomeScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun loadingState_showsLoadingMessage() {
+        composeRule.setContent {
+            HomeScreen(
+                uiState = HomeUiState.Loading,
+                onRefresh = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Loading users...").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyState_showsEmptyMessage() {
+        composeRule.setContent {
+            HomeScreen(
+                uiState = HomeUiState.Empty,
+                onRefresh = {}
+            )
+        }
+
+        composeRule.onNodeWithText("No users found").assertIsDisplayed()
+    }
+
+    @Test
+    fun errorState_showsErrorAndRetry_andInvokesCallback() {
+        var retryCount = 0
+
+        composeRule.setContent {
+            HomeScreen(
+                uiState = HomeUiState.Error("Network down"),
+                onRefresh = { retryCount++ }
+            )
+        }
+
+        composeRule.onNodeWithText("Unable to load users").assertIsDisplayed()
+        composeRule.onNodeWithText("Network down").assertIsDisplayed()
+        composeRule.onNodeWithText("Retry").performClick()
+
+        Assert.assertEquals(1, retryCount)
+    }
+
+    @Test
+    fun successState_showsUserNames() {
+        val users = listOf(
+            User(1, "Jeff Atwood", 9001, null),
+            User(2, "Joel Spolsky", 8000, null)
+        )
+
+        composeRule.setContent {
+            HomeScreen(
+                uiState = HomeUiState.Success(users),
+                onRefresh = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Jeff Atwood").assertIsDisplayed()
+        composeRule.onNodeWithText("Joel Spolsky").assertIsDisplayed()
+    }
+
+    @Test
+    fun polaroidGrid_showsInitialsPlaceholder_whenNoImageUrl() {
+        val users = listOf(
+            User(1, "Jeff Atwood", 9001, null)
+        )
+
+        composeRule.setContent {
+            UsersPolaroidGridView(users = users)
+        }
+
+        composeRule.onNodeWithText("JA").assertIsDisplayed()
+        composeRule.onNodeWithText("Jeff Atwood").assertIsDisplayed()
+        composeRule.onNodeWithText("9k").assertIsDisplayed()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".StackOverflowApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/stackoverflowapp/data/repo/fake/FakeUserRepository.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/repo/fake/FakeUserRepository.kt
@@ -9,8 +9,13 @@ class FakeUserRepository: UserRepository {
         with(delay(400)) {
             Result.success(
                 listOf(
-                    User(1, "Jeff Atwood", 9001, null),
-                    User(1, "Joel Spolsky", 8000, null)
+                    User(1, "Jeff Atwood", 9001, "https://upload.wikimedia.org/wikipedia/commons/3/36/Long_Zheng%2C_Dan_Rigsby%2C_Jeff_Atwood_%282979598012%29.jpg"),
+                    User(2, "Joel Spolsky", 8000, "https://upload.wikimedia.org/wikipedia/commons/8/81/Joel_Spolsky_2014-06-18_%28cropped%29.jpg"),
+                    User(3, "Charlie Brown", 1, "https://static.wikia.nocookie.net/bstudios/images/9/9b/Charlie-brown.png/revision/latest?cb=20161220204511"),
+                    User(4, "John Doe", 27, null),
+                    User(5, "Abigail Sparks", 1001, null),
+                    User(6, "Jake Warburton", 53, null),
+                    User(7, "Harry Fisher", 1337, null),
                 )
             )
         }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/MainActivity.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import com.example.stackoverflowapp.StackOverflowApp
 import com.example.stackoverflowapp.di.AppContainer
-import com.example.stackoverflowapp.ui.components.LoadingStateView
+import com.example.stackoverflowapp.ui.components.HomeRoute
+import com.example.stackoverflowapp.ui.home.HomeViewModel
+import com.example.stackoverflowapp.ui.home.HomeViewModelFactory
 import com.example.stackoverflowapp.ui.theme.StackOverflowTheme
 
 class MainActivity: ComponentActivity() {
@@ -15,12 +18,16 @@ class MainActivity: ComponentActivity() {
         (application as StackOverflowApp).container
     }
 
+    private val viewModel: HomeViewModel by viewModels {
+        HomeViewModelFactory(appContainer.userRepository)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             StackOverflowTheme {
-                LoadingStateView()
+                HomeRoute(viewModel = viewModel)
             }
         }
     }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/EmptyStateView.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/EmptyStateView.kt
@@ -1,0 +1,41 @@
+package com.example.stackoverflowapp.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyStateView(
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/ErrorStateView.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/ErrorStateView.kt
@@ -1,0 +1,49 @@
+package com.example.stackoverflowapp.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorStateView(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Unable to load users",
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.padding(top = 16.dp)
+        ) {
+            Text("Retry")
+        }
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/HomeRoute.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/HomeRoute.kt
@@ -1,0 +1,18 @@
+package com.example.stackoverflowapp.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.example.stackoverflowapp.ui.home.HomeViewModel
+
+@Composable
+fun HomeRoute(
+    viewModel: HomeViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    HomeScreen(
+        uiState = uiState,
+        onRefresh = viewModel::loadUsers
+    )
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/HomeScreen.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/HomeScreen.kt
@@ -1,0 +1,28 @@
+package com.example.stackoverflowapp.ui.components
+
+import androidx.compose.runtime.Composable
+import com.example.stackoverflowapp.ui.home.HomeUiState
+
+@Composable
+fun HomeScreen(
+    uiState: HomeUiState,
+    onRefresh: () -> Unit
+) {
+    when(uiState) {
+        HomeUiState.Loading -> LoadingScreen()
+
+        HomeUiState.Empty -> EmptyStateView(
+            title = "No users found",
+            message = "No StackOverflow users were returned."
+        )
+
+        is HomeUiState.Error -> ErrorStateView(
+            message = uiState.message,
+            onRetry = onRefresh
+        )
+
+        is HomeUiState.Success -> UsersPolaroidGridView(
+            users = uiState.users
+        )
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/LoadingScreen.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/LoadingScreen.kt
@@ -10,18 +10,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import com.example.stackoverflowapp.ui.theme.DiSerria
 import com.example.stackoverflowapp.ui.theme.Tradewind
 import com.example.stackoverflowapp.ui.theme.Zircon
-import kotlinx.coroutines.delay
 
 @Composable
 fun LoadingScreen(
@@ -75,26 +68,5 @@ fun LoadingScreen(
                 }
             }
         }
-    }
-}
-
-@Composable
-fun LoadingStateView() {
-    var isLoading by remember { mutableStateOf(true) }
-
-    LaunchedEffect(Unit) {
-        delay(1500) // fake loading
-        isLoading = false
-    }
-
-    if (isLoading) {
-        LoadingScreen()
-    } else {
-        Text(
-            text = "Users loaded",
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize()
-        )
     }
 }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/UsersPolaroidGridView.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/UsersPolaroidGridView.kt
@@ -1,0 +1,254 @@
+package com.example.stackoverflowapp.ui.components
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.stackoverflowapp.domain.model.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.math.abs
+
+@Composable
+fun UsersPolaroidGridView(
+    users: List<User>,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(
+            items = users,
+            key = { user -> user.id }
+        ) { user ->
+            CompactPolaroidUserCard(user = user)
+        }
+    }
+}
+
+@Composable
+private fun CompactPolaroidUserCard(
+    user: User
+) {
+    val tiltDegrees = tiltForUser(user.id)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .rotate(tiltDegrees),
+        shape = RoundedCornerShape(5.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFFEFB))
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 6.dp, top = 6.dp, end = 6.dp, bottom = 10.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(3f / 4f)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(Color(0xFFEDEFFF))
+            ) {
+                UserPhotoOrPlaceholder(
+                    imageUrl = user.profileImageUrl,
+                    displayName = user.displayName,
+                    modifier = Modifier.matchParentSize()
+                )
+
+                AssistChip(
+                    onClick = {},
+                    enabled = false,
+                    label = {
+                        Text(
+                            text = formatReputation(user.reputation),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 10.sp
+                        )
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        disabledContainerColor = Color(0xFFF0E1B8),
+                        disabledLabelColor = Color(0xFF6F530A)
+                    ),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(4.dp)
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, start = 4.dp, end = 4.dp, bottom = 2.dp)
+            ) {
+                Text(
+                    text = user.displayName,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color(0xFF1F1F1F),
+                    fontFamily = FontFamily.Serif,
+                    fontSize = 17.sp,
+                    lineHeight = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    fontStyle = FontStyle.Italic
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UserPhotoOrPlaceholder(
+    imageUrl: String?,
+    displayName: String,
+    modifier: Modifier = Modifier
+) {
+    val bitmapState by produceState<Bitmap?>(initialValue = null, imageUrl) {
+        value = if (imageUrl.isNullOrBlank()) {
+            null
+        } else {
+            loadBitmapFromUrl(imageUrl)
+        }
+    }
+
+    if (bitmapState != null) {
+        Image(
+            bitmap = bitmapState!!.asImageBitmap(),
+            contentDescription = "$displayName profile image",
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+        )
+    } else {
+        PolaroidPlaceholderPhoto(
+            displayName = displayName,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun PolaroidPlaceholderPhoto(
+    displayName: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(Color(0xFFEDEFFF)),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = Color(0xFFD9DFFF),
+            modifier = Modifier.size(52.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "$displayName profile placeholder",
+                    tint = Color(0xFF3B4260),
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+        }
+    }
+}
+
+private fun tiltForUser(id: Int): Float {
+    val normalized = ((abs(id * 1103515245 + 12345) % 900).toFloat() / 100f) - 2.5f
+    return normalized.coerceIn(-2.5f, 2.5f)
+}
+
+private fun formatReputation(reputation: Int): String {
+    return when {
+        reputation >= 1_000_000 -> {
+            val value = reputation / 1_000_000f
+            "${trimZeros(value)}M"
+        }
+
+        reputation >= 1_000 -> {
+            val value = reputation / 1_000f
+            "${trimZeros(value)}k"
+        }
+
+        else -> reputation.toString()
+    }
+}
+
+@SuppressLint("DefaultLocale")
+private fun trimZeros(value: Float): String {
+    val oneDecimal = String.format("%.1f", value)
+    return if (oneDecimal.endsWith(".0")) oneDecimal.dropLast(2) else oneDecimal
+}
+
+private suspend fun loadBitmapFromUrl(imageUrl: String): Bitmap? {
+    return withContext(Dispatchers.IO) {
+        runCatching {
+            val url = URL(imageUrl)
+            val connection = (url.openConnection() as HttpURLConnection).apply {
+                connectTimeout = 5_000
+                readTimeout = 5_000
+                instanceFollowRedirects = true
+                doInput = true
+            }
+
+            connection.connect()
+
+            if (connection.responseCode !in 200..299) {
+                connection.disconnect()
+                return@runCatching null
+            }
+
+            val bitmap = connection.inputStream.use { input ->
+                BitmapFactory.decodeStream(input)
+            }
+
+            connection.disconnect()
+            bitmap
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModel.kt
@@ -1,0 +1,37 @@
+package com.example.stackoverflowapp.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.stackoverflowapp.data.repo.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel(
+    private val userRepository: UserRepository
+): ViewModel() {
+
+    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    init {
+        loadUsers()
+    }
+
+    fun loadUsers() {
+        viewModelScope.launch {
+            _uiState.value = HomeUiState.Loading
+            val result = userRepository.fetchTopUsers()
+
+            _uiState.value = if (result.isSuccess) {
+                val users = result.getOrDefault(emptyList())
+                users.toHomeUiState()
+            } else {
+                HomeUiState.Error(result.exceptionOrNull()?.message ?: "Something went wrong")
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModelFactory.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.stackoverflowapp.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.stackoverflowapp.data.repo.UserRepository
+
+class HomeViewModelFactory(
+    private val userRepository: UserRepository
+): ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HomeViewModel::class.java)) {
+            return HomeViewModel(userRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/test/java/com/example/stackoverflowapp/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/MainDispatcherRule.kt
@@ -1,0 +1,24 @@
+package com.example.stackoverflowapp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/example/stackoverflowapp/ui/home/FakeTestUserRepo.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/ui/home/FakeTestUserRepo.kt
@@ -1,0 +1,17 @@
+package com.example.stackoverflowapp.ui.home
+
+import com.example.stackoverflowapp.data.repo.UserRepository
+import com.example.stackoverflowapp.domain.model.User
+
+class FakeTestUserRepository(
+    private val result: Result<List<User>>
+) : UserRepository {
+
+    var fetchCallCount = 0
+        private set
+
+    override suspend fun fetchTopUsers(): Result<List<User>> {
+        fetchCallCount++
+        return result
+    }
+}

--- a/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelFactoryTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelFactoryTest.kt
@@ -1,0 +1,23 @@
+package com.example.stackoverflowapp.ui.home
+
+import com.example.stackoverflowapp.data.repo.UserRepository
+import com.example.stackoverflowapp.domain.model.User
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeViewModelFactoryTest {
+
+    private val fakeRepo = object : UserRepository {
+        override suspend fun fetchTopUsers(): Result<List<User>> = Result.success(emptyList())
+    }
+
+    @Test
+    fun `create returns HomeViewModel when requested class is HomeViewModel`() {
+        val factory = HomeViewModelFactory(fakeRepo)
+
+        val viewModel = factory.create(HomeViewModel::class.java)
+
+        @Suppress("USELESS_IS_CHECK")
+        assertTrue(viewModel is HomeViewModel)
+    }
+}

--- a/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.example.stackoverflowapp.ui.home
+
+import com.example.stackoverflowapp.MainDispatcherRule
+import com.example.stackoverflowapp.domain.model.User
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `init loads users and emits Success when repository returns non-empty list`() = runTest {
+        val users = listOf(
+            User(id = 1, displayName = "Jeff Atwood", reputation = 9001, profileImageUrl = null)
+        )
+        val repo = FakeTestUserRepository(Result.success(users))
+
+        val viewModel = HomeViewModel(repo)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is HomeUiState.Success)
+        assertEquals(users, (state as HomeUiState.Success).users)
+        assertEquals(1, repo.fetchCallCount)
+    }
+
+    @Test
+    fun `init emits Empty when repository returns empty list`() = runTest {
+        val repo = FakeTestUserRepository(Result.success(emptyList()))
+
+        val viewModel = HomeViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(HomeUiState.Empty, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `init emits Error when repository returns failure`() = runTest {
+        val repo = FakeTestUserRepository(Result.failure(Exception("Network down")))
+
+        val viewModel = HomeViewModel(repo)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is HomeUiState.Error)
+        assertEquals("Network down", (state as HomeUiState.Error).message)
+    }
+
+    @Test
+    fun `loadUsers retries and calls repository again`() = runTest {
+        val users = listOf(
+            User(id = 1, displayName = "Joel Spolsky", reputation = 8000, profileImageUrl = null)
+        )
+        val repo = FakeTestUserRepository(Result.success(users))
+        val viewModel = HomeViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.loadUsers()
+        advanceUntilIdle()
+
+        assertEquals(2, repo.fetchCallCount)
+        assertTrue(viewModel.uiState.value is HomeUiState.Success)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,18 +5,20 @@ composeBom = "2026.02.00"
 kotlin = "2.3.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.3.0"
-espressoCore = "3.7.0"
+junitVersion = "1.1.5"
+espressoCore = "3.5.0"
 kotlinxCoroutinesAndroid = "1.10.2"
 kotlinxCoroutinesCore = "1.10.2"
 kotlinxCoroutinesTest = "1.10.2"
 lifecycleRuntimeCompose = "2.10.0"
 lifecycleViewmodelCompose = "2.10.0"
 lifecycleViewmodelKtx = "2.10.0"
+uiTestJunit4 = "1.10.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
@@ -33,6 +35,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "uiTestJunit4" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 🎯 Ticket
[[SOFA-15 – Create ViewModel with repository dependency]](https://github.com/rootMu/StackOverflowApp/issues/15)

---

## Summary
Moves screen logic and state management out of the composable UI layer into a `HomeViewModel` backed by the repository.

This PR adds:
- `HomeViewModel` with `UserRepository` dependency
- `HomeViewModelFactory` for injecting the repository from `AppContainer`
- `StateFlow`-based `HomeUiState` exposure (`Loading`, `Success`, `Empty`, `Error`)
- A state-driven screen flow (`HomeRoute` / `HomeScreen`) so composables only render UI state
- No data-fetching logic inside composables (fetching now happens in the ViewModel)

This sets up a cleaner architecture boundary and makes the screen easier to test.

---

## Tests Added
- ViewModel emits `Success` when repository returns a non-empty list
- ViewModel emits `Empty` when repository returns an empty list
- ViewModel emits `Error` when repository returns a failure
- ViewModel retry/load triggers repository fetch again
- ViewModelFactory creates `HomeViewModel`
- `HomeScreen` renders `Loading`, `Empty`, `Error`, and `Success` states correctly
- `Error` state retry action invokes callback (Compose UI test)