### PR TITLE
SOFA-10: Define API request and response layer interfaces

### DIFF
--- a/app/src/main/java/com/example/stackoverflowapp/data/api/ApiResult.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/ApiResult.kt
@@ -1,0 +1,12 @@
+package com.example.stackoverflowapp.data.api
+
+sealed interface ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>
+
+    sealed interface Error : ApiResult<Nothing> {
+        data class Network(val message: String) : Error
+        data class Http(val code: Int, val message: String? = null) : Error
+        data class Parse(val message: String) : Error
+        data object EmptyBody : Error
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/BadgeCountsDto.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/BadgeCountsDto.kt
@@ -1,0 +1,7 @@
+package com.example.stackoverflowapp.data.api
+
+data class BadgeCountsDto(
+    val bronze: Int,
+    val silver: Int,
+    val gold: Int
+)

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/StackoverflowUsersApi.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/StackoverflowUsersApi.kt
@@ -1,0 +1,5 @@
+package com.example.stackoverflowapp.data.api
+
+interface StackoverflowUsersApi {
+    suspend fun fetchTopUsers(page: Int = 1, pageSize: Int = 20): ApiResult<UsersResponseDto>
+}

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/UserDto.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/UserDto.kt
@@ -1,0 +1,9 @@
+package com.example.stackoverflowapp.data.api
+
+data class UserDto(
+    val userId: Int,
+    val displayName: String,
+    val reputation: Int,
+    val profileImageUrl: String?,
+    val badgeCounts: BadgeCountsDto? = null
+)

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/UsersRequest.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/UsersRequest.kt
@@ -1,0 +1,9 @@
+package com.example.stackoverflowapp.data.api
+
+data class UsersRequest (
+    val page: Int = 1,
+    val pageSize: Int = 20,
+    val order: String = "desc",
+    val sort: String = "reputation",
+    val site: String = "stackoverflow"
+)

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseDto.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseDto.kt
@@ -1,0 +1,5 @@
+package com.example.stackoverflowapp.data.api
+
+data class UsersResponseDto(
+    val items: List<UserDto>
+)

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseParser.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseParser.kt
@@ -1,0 +1,5 @@
+package com.example.stackoverflowapp.data.api
+
+interface UsersResponseParser {
+    fun parseUsersResponse(json: String): UsersResponseDto
+}


### PR DESCRIPTION
## 🎯 Ticket
[[SOFA-10 – Define API request and response layer interfaces]](https://github.com/rootMu/StackOverflowApp/issues/10)

---

## Summary
Defines a clear API request/response layer in `data/api` so networking and parsing responsibilities can remain separate from the repository and UI layers.

This PR adds:
- `StackOverflowUsersApi` interface to define the contract for fetching the initial StackOverflow users endpoint
- `UsersResponseParser` interface to define JSON-to-response parsing responsibility
- Response DTO models (`UsersResponseDto`, `UserDto`, `BadeCountsDto`) to represent the API response shape for parsing and mapping
- API result contract (`ApiResult`) for returning parsed responses and API-level failures
