### PR TITLE
SOFA-11: Add JSON parsing strategy using platform approach

### DIFF
--- a/app/src/androidTest/java/com/example/stackoverflowapp/data/parser/JsonUsersResponseParserTest.kt
+++ b/app/src/androidTest/java/com/example/stackoverflowapp/data/parser/JsonUsersResponseParserTest.kt
@@ -1,0 +1,66 @@
+package com.example.stackoverflowapp.data.parser
+
+import org.junit.Assert
+import org.junit.Test
+
+class JsonUsersResponseParserTest {
+
+    private val parser: UsersResponseParser = JsonUsersResponseParser()
+
+    @Test
+    fun parseUsersResponse_parsesSingleUser() {
+        val json = """
+            {
+              "items": [
+                {
+                  "user_id": 22656,
+                  "display_name": "Jon Skeet",
+                  "reputation": 1454978,
+                  "profile_image": "https://example.com/jon.png",
+                  "badge_counts": {
+                    "bronze": 9255,
+                    "silver": 9202,
+                    "gold": 877
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = parser.parseUsersResponse(json)
+
+        Assert.assertEquals(1, result.items.size)
+        val user = result.items.first()
+        Assert.assertEquals(22656, user.userId)
+        Assert.assertEquals("Jon Skeet", user.displayName)
+        Assert.assertEquals(1454978, user.reputation)
+        Assert.assertEquals("https://example.com/jon.png", user.profileImageUrl)
+        Assert.assertEquals(877, user.badgeCounts?.gold)
+    }
+
+    @Test
+    fun parseUsersResponse_handlesNullOptionalFields() {
+        val json = """
+            {
+              "items": [
+                {
+                  "user_id": 1,
+                  "display_name": "No Image User",
+                  "reputation": 100,
+                  "profile_image": null
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = parser.parseUsersResponse(json)
+
+        Assert.assertEquals(1, result.items.size)
+        Assert.assertNull(result.items.first().profileImageUrl)
+    }
+
+    @Test(expected = JsonParsingException::class)
+    fun parseUsersResponse_throwsControlledException_forInvalidJson() {
+        parser.parseUsersResponse("{ invalid json")
+    }
+}

--- a/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseParser.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/api/UsersResponseParser.kt
@@ -1,5 +1,0 @@
-package com.example.stackoverflowapp.data.api
-
-interface UsersResponseParser {
-    fun parseUsersResponse(json: String): UsersResponseDto
-}

--- a/app/src/main/java/com/example/stackoverflowapp/data/parser/JsonUsersResponseParser.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/parser/JsonUsersResponseParser.kt
@@ -1,0 +1,77 @@
+package com.example.stackoverflowapp.data.parser
+
+import com.example.stackoverflowapp.data.api.BadgeCountsDto
+import com.example.stackoverflowapp.data.api.UserDto
+import com.example.stackoverflowapp.data.api.UsersResponseDto
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+class JsonUsersResponseParser : UsersResponseParser {
+
+    override fun parseUsersResponse(json: String): UsersResponseDto {
+        return try {
+            val root = JSONObject(json)
+            val itemsArray = root.optJSONArray("items") ?: JSONArray()
+
+            val users = buildList {
+                for (index in 0 until itemsArray.length()) {
+                    val item = itemsArray.optJSONObject(index) ?: continue
+                    parseUser(item)?.let(::add)
+                }
+            }
+
+            UsersResponseDto(items = users)
+        } catch (e: JSONException) {
+            throw JsonParsingException("Failed to parse users response JSON", e)
+        } catch (e: Exception) {
+            throw JsonParsingException("Unexpected error while parsing users response", e)
+        }
+    }
+
+    private fun parseUser(json: JSONObject): UserDto? {
+        val userId = json.optIntOrNull("user_id") ?: return null
+        val displayName = json.optStringOrNull("display_name") ?: return null
+        val reputation = json.optIntOrNull("reputation") ?: 0
+        val profileImageUrl = json.optStringOrNull("profile_image")
+
+        val badgeCounts = json.optJSONObject("badge_counts")?.let { badgesJson ->
+            BadgeCountsDto(
+                bronze = badgesJson.optIntOrDefault("bronze", 0),
+                silver = badgesJson.optIntOrDefault("silver", 0),
+                gold = badgesJson.optIntOrDefault("gold", 0)
+            )
+        }
+
+        return UserDto(
+            userId = userId,
+            displayName = displayName,
+            reputation = reputation,
+            profileImageUrl = profileImageUrl,
+            badgeCounts = badgeCounts
+        )
+    }
+}
+
+class JsonParsingException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+private fun JSONObject.optStringOrNull(key: String): String? {
+    if (!has(key) || isNull(key)) return null
+    return optString(key).takeIf { it.isNotBlank() }
+}
+
+private fun JSONObject.optIntOrNull(key: String): Int? {
+    if (!has(key) || isNull(key)) return null
+    return try {
+        getInt(key)
+    } catch (_: JSONException) {
+        null
+    }
+}
+
+private fun JSONObject.optIntOrDefault(key: String, default: Int): Int {
+    return optIntOrNull(key) ?: default
+}

--- a/app/src/main/java/com/example/stackoverflowapp/data/parser/UsersResponseParser.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/parser/UsersResponseParser.kt
@@ -1,0 +1,7 @@
+package com.example.stackoverflowapp.data.parser
+
+import com.example.stackoverflowapp.data.api.UsersResponseDto
+
+interface UsersResponseParser {
+    fun parseUsersResponse(json: String): UsersResponseDto
+}


### PR DESCRIPTION
## 🎯 Ticket
[[SOFA-11 – Add JSON parsing strategy using platform or stdlib approach]](https://github.com/rootMu/StackOverflowApp/issues/11)

---

## Summary
Implements a JSON parsing strategy for the StackOverflow users endpoint using platform APIs (`org.json`) and keeps parsing isolated from repository and UI logic.

This PR adds:
- `JsonUsersResponseParser` in `data/parser`
- Safe manual parsing of the first endpoint response into DTOs (`UsersResponseDto`, `UserDto`, nested DTOs as applicable)
- Controlled parsing failure handling via a parsing exception (`JsonParsingException`) for malformed/unexpected JSON
- Null/missing field handling for optional response fields (e.g. `profile_image`, nested objects)

The parser output is ready for DTO-to-domain mapping in the repository layer.
