### PR TITLE
SOFA-39: Implement Pagination and Infinite Scrolling for StackOverflow Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The project is organized into the following layers:
 - **User Details Page**: Tapping a user opens a dedicated details screen with richer profile information including badges, reputation, location, website, and bio.
 - **Shared Element Transitions**: Smooth shared transitions animate the selected user card and image from the grid into the details screen.
 - **Search, Sort, and Favourites Filtering**: Supports real-time user filtering and sorting, with an optional favourites-only view.
+- **Pagination**: Fetches additional users from the Stack Overflow API as the user scrolls, with a loading indicator and end-of-list detection.
 - **Persistent Following System**: Followed users are stored locally and remain persisted independently of API refreshes.
 - **Manual Image Loading & Memory Caching**: Profile images are fetched, decoded, cached, and displayed without third-party image libraries.
 - **Offline-Friendly Cache Behaviour**:
@@ -174,7 +175,6 @@ The app supports both cached user lists and richer detail fetches.
 - **UI**: Core features including User Search, Filtering, and User Favouriting are fully functional.
 
 ### Roadmap
-- [ ] **Pagination**: Implement a paging mechanism to fetch more users from the Stack Overflow API as the user scrolls.
 - [ ] **Multi-List Support**: Allow users to switch between different types of user lists (e.g., "Top Reputed", "Recently Active", "New Users").
 - [ ] **Advanced Filtering**: Add more granular filtering options (e.g., filter by location, tags, or specific reputation ranges).
 - [ ] **Offline Mode**: Enhance the local storage strategy to support a full offline-first experience.

--- a/app/src/androidTest/java/com/example/stackoverflowapp/fakes/FakeUserRepository.kt
+++ b/app/src/androidTest/java/com/example/stackoverflowapp/fakes/FakeUserRepository.kt
@@ -5,46 +5,72 @@ import com.example.stackoverflowapp.domain.model.User
 import kotlinx.coroutines.delay
 
 /**
- * A fake implementation of [UserRepository] that simulates network latency.
+ * A fake implementation of [UserRepository] that simulates network latency and pagination.
  *
- * The [delay] in each method ensures that coroutines suspend, allowing tests
- * to verify intermediate states like 'Loading' or 'Refreshing'.
+ * This fake allows for granular control over network responses:
+ * 1. Simulates latency via [delay] to test loading states.
+ * 2. Can "hold" loading indefinitely using [shouldHoldLoading].
+ * 3. Supports page-specific results for pagination testing.
+ *
+ * @param result The default result returned for all pages unless overridden.
  */
 class FakeUserRepository(private var result: Result<List<User>>) : UserRepository {
+
+    /**
+     * Total number of times any fetch method was called.
+     */
     var fetchCallCount = 0
         private set
+
+    /**
+     * Total number of times [refreshUsers] was called.
+     */
     var refreshCallCount = 0
         private set
 
+    /**
+     * An optional override for user details results.
+     */
     var userDetailsResult: Result<User>? = null
-    
+
     /**
      * If true, repository calls will suspend indefinitely to simulate a long loading state.
+     * Useful for testing UI components like progress indicators.
      */
     var shouldHoldLoading: Boolean = false
 
-    override suspend fun fetchTopUsers(): Result<List<User>> {
-        if (shouldHoldLoading) delay(Long.MAX_VALUE)
+    private val resultsByPage = mutableMapOf<Int, Result<List<User>>>()
+
+    override suspend fun fetchTopUsers(page: Int): Result<List<User>> {
+        handleLoadingSimulation()
         fetchCallCount++
-        delay(10)
-        return result
+        return resultsByPage[page] ?: result
     }
 
     override suspend fun fetchUserDetails(userId: Int): Result<User> {
-        if (shouldHoldLoading) delay(Long.MAX_VALUE)
+        handleLoadingSimulation()
         fetchCallCount++
-        delay(10)
-        
+
         return userDetailsResult ?: result.mapCatching { users ->
-            users.first { it.id == userId }
+            users.firstOrNull { it.id == userId }
+                ?: throw NoSuchElementException("User with id $userId not found in fake")
         }
     }
 
     override suspend fun refreshUsers(): Result<List<User>> {
-        if (shouldHoldLoading) delay(Long.MAX_VALUE)
+        handleLoadingSimulation()
         fetchCallCount++
         refreshCallCount++
+        return resultsByPage[1] ?: result
+    }
+
+    /**
+     * Helper to centralize loading simulation logic.
+     */
+    private suspend fun handleLoadingSimulation() {
+        if (shouldHoldLoading) {
+            delay(Long.MAX_VALUE)
+        }
         delay(10)
-        return result
     }
 }

--- a/app/src/androidTest/java/com/example/stackoverflowapp/ui/components/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/example/stackoverflowapp/ui/components/HomeScreenTest.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import com.example.stackoverflowapp.data.image.ImageLoader
 import com.example.stackoverflowapp.domain.model.SharedTransitionTestContext
 import com.example.stackoverflowapp.domain.model.createTestUser
@@ -22,13 +25,16 @@ import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
+/**
+ * UI tests for the [HomeScreen] composable.
+ */
 @OptIn(ExperimentalSharedTransitionApi::class)
 class HomeScreenTest {
 
     @get:Rule
     val composeRule = createComposeRule()
 
-    val fakeImageLoader = object : ImageLoader {
+    private val fakeImageLoader = object : ImageLoader {
         override suspend fun loadBitmap(url: String): Bitmap? = null
         override fun getCachedBitmap(url: String): Bitmap? = null
     }
@@ -44,6 +50,7 @@ class HomeScreenTest {
                     onRetry = {},
                     onUserClick = {},
                     onFollowClick = {},
+                    onLoadMore = {},
                     sharedTransitionScope = this,
                     animatedContentScope = animatedScope
                 )
@@ -64,6 +71,7 @@ class HomeScreenTest {
                     onRetry = {},
                     onUserClick = {},
                     onFollowClick = {},
+                    onLoadMore = {},
                     sharedTransitionScope = this,
                     animatedContentScope = animatedScope
                 )
@@ -85,6 +93,7 @@ class HomeScreenTest {
                     onRetry = {},
                     onUserClick = {},
                     onFollowClick = {},
+                    onLoadMore = {},
                     sharedTransitionScope = this,
                     animatedContentScope = animatedScope
                 )
@@ -105,6 +114,7 @@ class HomeScreenTest {
                     onRetry = {},
                     onUserClick = {},
                     onFollowClick = {},
+                    onLoadMore = {},
                     sharedTransitionScope = this,
                     animatedContentScope = animatedScope
                 )
@@ -127,6 +137,7 @@ class HomeScreenTest {
                     onRetry = { retryCount++ },
                     onUserClick = {},
                     onFollowClick = {},
+                    onLoadMore = {},
                     sharedTransitionScope = this,
                     animatedContentScope = animatedScope
                 )
@@ -151,7 +162,7 @@ class HomeScreenTest {
         composeRule.setContent {
             SharedTransitionLayout {
                 AnimatedContent(targetState = true, label = "test") { animatedState ->
-                    if(animatedState) {
+                    if (animatedState) {
                         CompositionLocalProvider(
                             LocalSharedTransitionScope provides this@SharedTransitionLayout,
                             LocalAnimatedVisibilityScope provides this@AnimatedContent
@@ -164,7 +175,8 @@ class HomeScreenTest {
                                 animatedContentScope = this@AnimatedContent,
                                 onRetry = {},
                                 onUserClick = {},
-                                onFollowClick = {}
+                                onFollowClick = {},
+                                onLoadMore = {}
                             )
                         }
                     }
@@ -174,5 +186,149 @@ class HomeScreenTest {
 
         composeRule.onNodeWithText("Jeff Atwood").assertIsDisplayed()
         composeRule.onNodeWithText("Joel Spolsky").assertIsDisplayed()
+    }
+
+    @Test
+    fun scrollingNearEnd_triggersOnLoadMore() {
+        var loadMoreCalled = false
+        val users = (1..60).map { createTestUser(id = it, name = "User $it") }
+        val uiModels = users.map { UserUiModel(it, false) }
+
+        composeRule.setContent {
+            SharedTransitionTestContext { animatedScope ->
+                HomeScreen(
+                    state = HomeScreenState(users = uiModels),
+                    gridState = rememberLazyGridState(),
+                    imageLoader = fakeImageLoader,
+                    onRetry = {},
+                    onUserClick = {},
+                    onFollowClick = {},
+                    onLoadMore = { loadMoreCalled = true },
+                    sharedTransitionScope = this,
+                    animatedContentScope = animatedScope
+                )
+            }
+        }
+
+        Assert.assertFalse(loadMoreCalled)
+
+        composeRule.onNodeWithTag("users_grid").performScrollToIndex(users.size - 1)
+        composeRule.waitUntil(timeoutMillis = 5000) { loadMoreCalled }
+        
+        Assert.assertTrue("onLoadMore should have been triggered by scroll", loadMoreCalled)
+    }
+
+    @Test
+    fun isLoadingMore_showsLoadingIndicator() {
+        val users = (1..2).map { createTestUser(id = it, name = "User $it") }
+        val uiModels = users.map { UserUiModel(it, false) }
+
+        composeRule.setContent {
+            SharedTransitionTestContext { animatedScope ->
+                HomeScreen(
+                    state = HomeScreenState(users = uiModels, isLoadingMore = true),
+                    gridState = rememberLazyGridState(),
+                    imageLoader = fakeImageLoader,
+                    onRetry = {},
+                    onUserClick = {},
+                    onFollowClick = {},
+                    onLoadMore = {},
+                    sharedTransitionScope = this,
+                    animatedContentScope = animatedScope
+                )
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 10000) {
+            composeRule.onAllNodesWithTag("pagination_loading_indicator").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag("users_grid").performScrollToIndex(uiModels.size)
+        composeRule.onNodeWithTag("pagination_loading_indicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun endReached_doesNotTriggerOnLoadMore() {
+        var loadMoreCalled = false
+        val users = (1..60).map { createTestUser(id = it, name = "User $it") }
+        val uiModels = users.map { UserUiModel(it, false) }
+
+        composeRule.setContent {
+            SharedTransitionTestContext { animatedScope ->
+                HomeScreen(
+                    state = HomeScreenState(users = uiModels, endReached = true),
+                    gridState = rememberLazyGridState(),
+                    imageLoader = fakeImageLoader,
+                    onRetry = {},
+                    onUserClick = {},
+                    onFollowClick = {},
+                    onLoadMore = { loadMoreCalled = true },
+                    sharedTransitionScope = this,
+                    animatedContentScope = animatedScope
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("users_grid").performScrollToIndex(users.size - 1)
+        
+        Thread.sleep(500)
+        
+        Assert.assertFalse("onLoadMore should NOT have been triggered because endReached is true", loadMoreCalled)
+    }
+
+    @Test
+    fun alreadyLoadingMore_doesNotTriggerOnLoadMoreAgain() {
+        var loadMoreCallCount = 0
+        val users = (1..60).map { createTestUser(id = it, name = "User $it") }
+        val uiModels = users.map { UserUiModel(it, false) }
+
+        composeRule.setContent {
+            SharedTransitionTestContext { animatedScope ->
+                HomeScreen(
+                    state = HomeScreenState(users = uiModels, isLoadingMore = true),
+                    gridState = rememberLazyGridState(),
+                    imageLoader = fakeImageLoader,
+                    onRetry = {},
+                    onUserClick = {},
+                    onFollowClick = {},
+                    onLoadMore = { loadMoreCallCount++ },
+                    sharedTransitionScope = this,
+                    animatedContentScope = animatedScope
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("users_grid").performScrollToIndex(users.size - 1)
+        
+        Thread.sleep(500)
+        
+        Assert.assertEquals("onLoadMore should NOT have been triggered because isLoadingMore is true", 0, loadMoreCallCount)
+    }
+
+    @Test
+    fun shortList_doesNotTriggerOnLoadMore() {
+        var loadMoreCalled = false
+        val users = (1..2).map { createTestUser(id = it, name = "User $it") }
+        val uiModels = users.map { UserUiModel(it, false) }
+
+        composeRule.setContent {
+            SharedTransitionTestContext { animatedScope ->
+                HomeScreen(
+                    state = HomeScreenState(users = uiModels),
+                    gridState = rememberLazyGridState(),
+                    imageLoader = fakeImageLoader,
+                    onRetry = {},
+                    onUserClick = {},
+                    onFollowClick = {},
+                    onLoadMore = { loadMoreCalled = true },
+                    sharedTransitionScope = this,
+                    animatedContentScope = animatedScope
+                )
+            }
+        }
+
+        composeRule.mainClock.advanceTimeBy(500)
+        
+        Assert.assertFalse("onLoadMore should NOT be triggered for a short list where all items are visible", loadMoreCalled)
     }
 }

--- a/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepository.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepository.kt
@@ -3,7 +3,7 @@ package com.example.stackoverflowapp.data.repo
 import com.example.stackoverflowapp.domain.model.User
 
 interface UserRepository {
-    suspend fun fetchTopUsers(): Result<List<User>>
+    suspend fun fetchTopUsers(page: Int = 1): Result<List<User>>
     suspend fun fetchUserDetails(userId: Int): Result<User>
     suspend fun refreshUsers(): Result<List<User>>
 }

--- a/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/data/repo/UserRepositoryImpl.kt
@@ -13,12 +13,14 @@ class UserRepositoryImpl(
     private val localDataSource: UserLocalDataSource
 ) : UserRepository {
 
-    override suspend fun fetchTopUsers(): Result<List<User>> {
-        val localUsers = localDataSource.getAllUsers()
-        if (localUsers.isNotEmpty()) {
-            return Result.success(localUsers)
+    override suspend fun fetchTopUsers(page: Int): Result<List<User>> {
+        if (page == 1) {
+            val localUsers = localDataSource.getAllUsers()
+            if (localUsers.isNotEmpty()) {
+                return Result.success(localUsers)
+            }
         }
-        return fetchUsersFromApi()
+        return fetchUsersFromApi(page = page)
     }
 
     override suspend fun fetchUserDetails(userId: Int): Result<User> {
@@ -42,11 +44,11 @@ class UserRepositoryImpl(
     private fun User.hasCompleteDetails(): Boolean = !aboutMe.isNullOrBlank()
 
     override suspend fun refreshUsers(): Result<List<User>> {
-        return fetchUsersFromApi(clearCache = true)
+        return fetchUsersFromApi(page = 1, clearCache = true)
     }
 
-    private suspend fun fetchUsersFromApi(clearCache: Boolean = false): Result<List<User>> {
-        return usersApi.fetchTopUsers(page = 1, pageSize = 20).toResult().map { response ->
+    private suspend fun fetchUsersFromApi(page: Int, clearCache: Boolean = false): Result<List<User>> {
+        return usersApi.fetchTopUsers(page = page, pageSize = 20).toResult().map { response ->
             val domainUsers = response.items.map { it.toDomain() }
             if (clearCache) localDataSource.clearAllUsers()
             localDataSource.insertUsers(domainUsers)

--- a/app/src/main/java/com/example/stackoverflowapp/ui/components/UsersPolaroidGridView.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/components/UsersPolaroidGridView.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,16 +31,19 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,6 +62,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.stackoverflowapp.data.image.ImageLoader
 import com.example.stackoverflowapp.domain.model.User
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlin.math.abs
 
 /**
@@ -80,12 +86,43 @@ fun UsersPolaroidGridView(
     sharedTransitionScope: SharedTransitionScope,
     animatedContentScope: AnimatedContentScope,
     contentPadding: PaddingValues,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isLoadingMore: Boolean = false,
+    isEndReached: Boolean = false,
+    onLoadMore: () -> Unit = {}
 ) {
+    val shouldLoadMore = remember(isLoadingMore, isEndReached) {
+        derivedStateOf {
+            if (isLoadingMore || isEndReached) return@derivedStateOf false
+            
+            val layoutInfo = gridState.layoutInfo
+            val totalItemsNumber = layoutInfo.totalItemsCount
+            val visibleItems = layoutInfo.visibleItemsInfo
+            
+            if (totalItemsNumber <= 0 || visibleItems.isEmpty()) {
+                false
+            } else {
+                val lastVisibleItemIndex = visibleItems.last().index + 1
+                lastVisibleItemIndex >= (totalItemsNumber - 4) && totalItemsNumber > visibleItems.size
+            }
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        snapshotFlow { shouldLoadMore.value }
+            .distinctUntilChanged()
+            .filter { it }
+            .collect {
+                onLoadMore()
+            }
+    }
+
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Fixed(2),
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .testTag("users_grid"),
         contentPadding = PaddingValues(
             start = 16.dp,
             end = 16.dp,
@@ -106,6 +143,23 @@ fun UsersPolaroidGridView(
                 animatedContentScope = animatedContentScope,
                 modifier = Modifier.animateItem()
             )
+        }
+
+        if (isLoadingMore) {
+            item(span = { GridItemSpan(2) }) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .testTag("pagination_loading_indicator")
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeRoute.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeRoute.kt
@@ -102,6 +102,7 @@ fun HomeRoute(
                 onRetry = viewModel::loadUsers,
                 onUserClick = onUserClick,
                 onFollowClick = viewModel::onFollowClick,
+                onLoadMore = viewModel::loadMoreUsers,
                 contentPadding = PaddingValues(0.dp)
             )
         }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeScreen.kt
@@ -23,12 +23,13 @@ fun HomeScreen(
     onRetry: () -> Unit,
     onUserClick: (Int) -> Unit,
     onFollowClick: (Int) -> Unit,
+    onLoadMore: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     when {
         state.isLoading && !state.isRefreshing -> LoadingScreen()
-        state.error != null -> ErrorStateView(
+        state.error != null && state.users.isEmpty() -> ErrorStateView(
             title = "Connection Error",
             message = "We couldn't connect to StackOverflow. Please check your connection and try again.",
             technicalDetails = state.error,
@@ -58,7 +59,10 @@ fun HomeScreen(
                 imageLoader = imageLoader,
                 sharedTransitionScope = sharedTransitionScope,
                 animatedContentScope = animatedContentScope,
-                contentPadding = contentPadding
+                contentPadding = contentPadding,
+                isLoadingMore = state.isLoadingMore,
+                isEndReached = state.endReached,
+                onLoadMore = onLoadMore
             )
         }
     }

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeUiState.kt
@@ -5,11 +5,13 @@ import com.example.stackoverflowapp.domain.model.User
 data class HomeScreenState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
+    val isLoadingMore: Boolean = false,
     val users: List<UserUiModel> = emptyList(),
     val searchQuery: String = "",
     val sortOrder: SortOrder = SortOrder.REPUTATION_DESC,
     val showFavouritesOnly: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val endReached: Boolean = false
 )
 
 data class UserUiModel(
@@ -25,7 +27,10 @@ sealed interface HomeUiState {
     data object Loading : HomeUiState
     data class Success(
         val users: List<User>,
-        val isRefreshing: Boolean = false
+        val isRefreshing: Boolean = false,
+        val isLoadingMore: Boolean = false,
+        val currentPage: Int = 1,
+        val endReached: Boolean = false
     ) : HomeUiState
     data object Empty : HomeUiState
     data class Error(val message: String) : HomeUiState

--- a/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/stackoverflowapp/ui/home/HomeViewModel.kt
@@ -34,6 +34,7 @@ class HomeViewModel(
         HomeScreenState(
             isLoading = state is HomeUiState.Loading,
             isRefreshing = (state as? HomeUiState.Success)?.isRefreshing ?: false,
+            isLoadingMore = (state as? HomeUiState.Success)?.isLoadingMore ?: false,
             users = if (state is HomeUiState.Success) {
                 state.users
                     .filter { it.displayName.contains(query, ignoreCase = true) }
@@ -46,7 +47,8 @@ class HomeViewModel(
             searchQuery = query,
             sortOrder = sort,
             showFavouritesOnly = favouritesOnly,
-            error = (state as? HomeUiState.Error)?.message
+            error = (state as? HomeUiState.Error)?.message,
+            endReached = (state as? HomeUiState.Success)?.endReached ?: false
         )
     }.stateIn(
         scope = viewModelScope,
@@ -82,33 +84,74 @@ class HomeViewModel(
 
     fun loadUsers() {
         viewModelScope.launch {
-            handleUserFetch { userRepository.fetchTopUsers() }
+            handleUserFetch(page = 1)
+        }
+    }
+
+    fun loadMoreUsers() {
+        val currentState = uiState.value as? HomeUiState.Success ?: return
+        if (currentState.isLoadingMore || currentState.endReached) return
+
+        _uiState.value = currentState.copy(isLoadingMore = true)
+
+        viewModelScope.launch {
+            handleUserFetch(page = currentState.currentPage + 1)
         }
     }
 
     fun refresh() {
-        val currentState = _uiState.value as? HomeUiState.Success ?: return
+        val currentState = uiState.value as? HomeUiState.Success ?: return
         _uiState.value = currentState.copy(isRefreshing = true)
 
         viewModelScope.launch {
-            handleUserFetch { userRepository.refreshUsers() }
+            val result = userRepository.refreshUsers()
+            _uiState.value = result.fold(
+                onSuccess = { users ->
+                    HomeUiState.Success(
+                        users = users,
+                        isRefreshing = false,
+                        currentPage = 1,
+                        endReached = users.isEmpty()
+                    )
+                },
+                onFailure = { _ ->
+                    currentState.copy(isRefreshing = false)
+                }
+            )
         }
     }
 
-    private suspend fun handleUserFetch(fetcher: suspend () -> Result<List<User>>) {
-        val result = fetcher()
-        val currentState = _uiState.value
+    private suspend fun handleUserFetch(page: Int) {
+        val result = userRepository.fetchTopUsers(page)
+        val currentState = uiState.value
 
         _uiState.value = result.fold(
-            onSuccess = { users ->
-                if (users.isEmpty()) HomeUiState.Empty
-                else HomeUiState.Success(users, isRefreshing = false)
+            onSuccess = { newUsers ->
+                if (page == 1) {
+                    if (newUsers.isEmpty()) HomeUiState.Empty
+                    else HomeUiState.Success(newUsers, currentPage = 1)
+                } else {
+                    val currentSuccess = currentState as? HomeUiState.Success
+                    if (currentSuccess != null) {
+                        val mergedUsers = (currentSuccess.users + newUsers).distinctBy { it.id }
+                        currentSuccess.copy(
+                            users = mergedUsers,
+                            isLoadingMore = false,
+                            currentPage = page,
+                            endReached = newUsers.isEmpty()
+                        )
+                    } else {
+                        HomeUiState.Success(newUsers, currentPage = page)
+                    }
+                }
             },
             onFailure = { error ->
-                if (currentState is HomeUiState.Success) {
-                    currentState.copy(isRefreshing = false)
-                } else {
-                    HomeUiState.Error(error.message ?: "Unknown Error")
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(
+                        isLoadingMore = false,
+                        isRefreshing = false
+                    )
+                    else -> HomeUiState.Error(error.message ?: "Unknown Error")
                 }
             }
         )

--- a/app/src/test/java/com/example/stackoverflowapp/data/repo/UserRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/data/repo/UserRepositoryImplTest.kt
@@ -56,18 +56,33 @@ class UserRepositoryImplTest {
     )
 
     @Test
-    fun `fetchTopUsers returns local data when available`() = runTest {
+    fun `fetchTopUsers returns local data when available on page 1`() = runTest {
         val user = createTestUser(1)
         val list = listOf(user)
         fakeDb.insertUsers(list)
 
         setupRepository(ApiResult.Success(list.toDto()))
 
-        val result = repository.fetchTopUsers()
+        val result = repository.fetchTopUsers(page = 1)
 
         Assert.assertTrue(result.isSuccess)
         Assert.assertEquals(user, result.getOrThrow().first())
         Assert.assertEquals(0, fakeApi.callCount)
+    }
+
+    @Test
+    fun `fetchTopUsers page 2 always calls API even if local data exists`() = runTest {
+        val user = createTestUser(1)
+        fakeDb.insertUsers(listOf(user))
+
+        val apiUser = createTestUser(2)
+        setupRepository(ApiResult.Success(listOf(apiUser).toDto()))
+
+        val result = repository.fetchTopUsers(page = 2)
+
+        Assert.assertTrue(result.isSuccess)
+        Assert.assertEquals(apiUser, result.getOrThrow().first())
+        Assert.assertEquals(1, fakeApi.callCount)
     }
 
     @Test

--- a/app/src/test/java/com/example/stackoverflowapp/fakes/FakeUserRepository.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/fakes/FakeUserRepository.kt
@@ -15,15 +15,21 @@ class FakeUserRepository(private var result: Result<List<User>>) : UserRepositor
         private set
     var refreshCallCount = 0
         private set
+
+    private val resultsByPage = mutableMapOf<Int, Result<List<User>>>()
     
     fun setResult(newResult: Result<List<User>>) {
         result = newResult
     }
 
-    override suspend fun fetchTopUsers(): Result<List<User>> {
+    fun setResultForPage(page: Int, newResult: Result<List<User>>) {
+        resultsByPage[page] = newResult
+    }
+
+    override suspend fun fetchTopUsers(page: Int): Result<List<User>> {
         fetchCallCount++
         delay(10)
-        return result
+        return resultsByPage[page] ?: result
     }
 
     override suspend fun fetchUserDetails(userId: Int): Result<User> {
@@ -38,6 +44,6 @@ class FakeUserRepository(private var result: Result<List<User>>) : UserRepositor
         fetchCallCount++
         refreshCallCount++
         delay(10)
-        return result
+        return resultsByPage[1] ?: result
     }
 }

--- a/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
@@ -328,7 +328,7 @@ class HomeViewModelTest {
     @Test
     fun `loadMoreUsers does not trigger if endReached`() = runTest {
         val repo = FakeUserRepository(Result.success(listOf(createTestUser(1))))
-        repo.setResultForPage(2, Result.success(emptyList())) // This will set endReached
+        repo.setResultForPage(2, Result.success(emptyList()))
         
         val viewModel = createViewModel(repo)
         backgroundCollect(viewModel.screenState)

--- a/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/stackoverflowapp/ui/home/HomeViewModelTest.kt
@@ -300,6 +300,52 @@ class HomeViewModelTest {
         assertEquals(1, state.users.size)
     }
 
+    @Test
+    fun `loadMoreUsers appends users and updates state`() = runTest {
+        val page1Users = listOf(createTestUser(1), createTestUser(2))
+        val page2Users = listOf(createTestUser(3), createTestUser(4))
+        
+        val repo = FakeUserRepository(Result.success(page1Users))
+        repo.setResultForPage(2, Result.success(page2Users))
+        
+        val viewModel = createViewModel(repo)
+        backgroundCollect(viewModel.screenState)
+        advanceUntilIdle()
+        
+        assertEquals(2, viewModel.screenState.value.users.size)
+        
+        viewModel.loadMoreUsers()
+        assertTrue(viewModel.screenState.value.isLoadingMore)
+        
+        advanceUntilIdle()
+        
+        val state = viewModel.screenState.value
+        assertFalse(state.isLoadingMore)
+        assertEquals(4, state.users.size)
+        assertEquals(3, state.users[2].user.id)
+    }
+
+    @Test
+    fun `loadMoreUsers does not trigger if endReached`() = runTest {
+        val repo = FakeUserRepository(Result.success(listOf(createTestUser(1))))
+        repo.setResultForPage(2, Result.success(emptyList())) // This will set endReached
+        
+        val viewModel = createViewModel(repo)
+        backgroundCollect(viewModel.screenState)
+        advanceUntilIdle()
+        
+        viewModel.loadMoreUsers()
+        advanceUntilIdle()
+        
+        assertTrue(viewModel.screenState.value.endReached)
+        val callCountAfterPage2 = repo.fetchCallCount
+        
+        viewModel.loadMoreUsers()
+        runCurrent()
+        
+        assertEquals("Should not have called repository again", callCountAfterPage2, repo.fetchCallCount)
+    }
+
     private fun createViewModel(
         repo: UserRepository,
         followedUsersRepository: FollowedUsersRepository = FakeFollowUserRepository(FakeUserStore())


### PR DESCRIPTION
## **Description**
This PR introduces pagination to the Home screen. As the user scrolls towards the bottom of the list, the app now automatically fetches the next page of StackOverflow "_Legends_," providing a seamless infinite scroll experience.
### Key Changes
- **State Management**: Updated HomeScreenState to include isLoadingMore and endReached flags to properly manage pagination lifecycle.
- **Scroll Trigger**: Integrated logic within the LazyVerticalGrid to invoke onLoadMore when the user nears the end of the current list.
- **Loading UX**: Added a CircularProgressIndicator (tagged pagination_loading_indicator) at the bottom of the grid to provide visual feedback during background fetches.
- **Guard Logic**: Implemented checks to ensure onLoadMore is not triggered if a request is already in progress or if the server has no more data to provide.

### **Test Coverage**: 
#### Expanded `HomeScreenTest.kt` with 5 new test cases covering:
- Successful scroll-to-load triggers.
- Display of the pagination loading indicator.
- Prevention of loading when endReached is true.
- Prevention of duplicate calls when isLoadingMore is true.
- Ensuring short lists don't accidentally trigger loads- 